### PR TITLE
feat: add nav-link component for i18n client-side nav

### DIFF
--- a/src/components/app-footer.vue
+++ b/src/components/app-footer.vue
@@ -1,14 +1,11 @@
 <script lang="ts" setup>
-import { type NuxtLinkProps } from "#app";
+import { type NavLinkProps } from "@/components/nav-link.vue";
 
 const t = useTranslations("AppFooter");
-const localePath = useLocalePath();
-
-type Href = Exclude<NuxtLinkProps["href"], string>;
 
 const links = {
-	imprint: { href: { path: localePath("/imprint") }, label: t("links.imprint") },
-} satisfies Record<string, { href: Href; label: string }>;
+	imprint: { href: { path: "/imprint" }, label: t("links.imprint") },
+} satisfies Record<string, { href: NavLinkProps["href"]; label: string }>;
 </script>
 
 <template>
@@ -16,9 +13,9 @@ const links = {
 		<nav :aria-label="t('navigation-secondary')">
 			<ul role="list">
 				<li v-for="(link, key) of links" :key="key">
-					<NuxtLink :href="link.href">
+					<NavLink :href="link.href">
 						{{ link.label }}
-					</NuxtLink>
+					</NavLink>
 				</li>
 			</ul>
 		</nav>

--- a/src/components/app-header.vue
+++ b/src/components/app-header.vue
@@ -1,14 +1,11 @@
 <script lang="ts" setup>
-import { type NuxtLinkProps } from "#app";
+import { type NavLinkProps } from "@/components/nav-link.vue";
 
 const t = useTranslations("AppHeader");
-const localePath = useLocalePath();
-
-type Href = Exclude<NuxtLinkProps["href"], string>;
 
 const links = {
-	home: { href: { path: localePath("/") }, label: t("links.home") },
-} satisfies Record<string, { href: Href; label: string }>;
+	home: { href: { path: "/" }, label: t("links.home") },
+} satisfies Record<string, { href: NavLinkProps["href"]; label: string }>;
 </script>
 
 <template>
@@ -16,9 +13,9 @@ const links = {
 		<nav :aria-label="t('navigation-main')">
 			<ul role="list">
 				<li v-for="(link, key) of links" :key="key">
-					<NuxtLink :href="link.href">
+					<NavLink :href="link.href">
 						{{ link.label }}
-					</NuxtLink>
+					</NavLink>
 				</li>
 			</ul>
 		</nav>

--- a/src/components/nav-link.vue
+++ b/src/components/nav-link.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import { type NuxtLinkProps } from "#app";
+
+export interface NavLinkProps
+	extends Omit<NuxtLinkProps, "href" | "to">,
+		Required<Pick<NuxtLinkProps, "href">> {}
+
+const props = defineProps<NavLinkProps>();
+
+const localePath = useLocalePath();
+</script>
+
+<template>
+	<NuxtLink :href="localePath(props.href as any /** Type mismatch. */)">
+		<slot />
+	</NuxtLink>
+</template>


### PR DESCRIPTION
this adds a `NavLink` component which automatically wraps hrefs with `useLocalePath`.

note that we cannot simply name this `Link` since that is a nuxt builtin, and thus would conflict with auto-imports :(