### PR TITLE
feat: default to disallowing web crawlers

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -42,6 +42,9 @@ export default defineNuxtConfig({
 		},
 	},
 	routeRules: {
+		"**/*": {
+			headers: process.env.BOTS !== "enabled" ? { "X-Robots-Tag": "noindex, nofollow" } : {},
+		},
 		"/": { static: true },
 		"/imprint": { static: true },
 	},


### PR DESCRIPTION
disallow web crawlers unless the `BOTS` environment variable is set to "enabled"