### PR TITLE
build: remove `use-node-version` setting from `.npmrc`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,3 @@
 engine-strict=true
 package-manager-strict=false
 shell-emulator=true
-use-node-version=20.14.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,10 @@ WORKDIR /app
 USER node
 
 COPY --chown=node:node .npmrc package.json pnpm-lock.yaml ./
-RUN sed -i "s/use-node-version/# use-node-version/" .npmrc
 
 RUN pnpm fetch
 
 COPY --chown=node:node ./ ./
-RUN sed -i "s/use-node-version/# use-node-version/" .npmrc
 
 ARG NUXT_PUBLIC_APP_BASE_URL
 ARG NUXT_PUBLIC_BOTS

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,10 @@ prerequisites:
 - [node.js 20.x](https://nodejs.org/en/download)
 - [pnpm 9.x](https://pnpm.io/installation)
 
+> [!TIP]
+>
+> you can use `pnpm` to install the required node.js version with `pnpm env use 20 --global`
+
 set required environment variables in `.env.local`:
 
 ```bash


### PR DESCRIPTION
feedback has been that `pnpm`'s `use-node-version` setting in `.npmrc`, which allows specifying an exact node version for `pnpm` to download and use, is confusing. this removes it, and instead adds a short note to the readme.