### PR TITLE
chore: replace prettier with biome

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,10 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"biomejs.biome",
 				"bradlc.vscode-tailwindcss",
 				"dbaeumer.vscode-eslint",
 				"editorconfig.editorconfig",
-				"esbenp.prettier-vscode",
 				"lokalise.i18n-ally",
 				"mikestead.dotenv",
 				"ms-playwright.playwright",

--- a/.vscode/app.code-snippets
+++ b/.vscode/app.code-snippets
@@ -19,7 +19,7 @@
 			"\t<MainContent class=\"container grid content-start gap-y-8 py-8\">",
 			"\t\t<PageTitle>{{ t(\"${1:Name}Page.title\") }}</PageTitle>",
 			"\t</MainContent>",
-			"</template>",
-		],
-	},
+			"</template>"
+		]
+	}
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
 	"recommendations": [
+		"biomejs.biome",
 		"bradlc.vscode-tailwindcss",
 		"dbaeumer.vscode-eslint",
 		"editorconfig.editorconfig",
-		"esbenp.prettier-vscode",
 		"lokalise.i18n-ally",
 		"mikestead.dotenv",
 		"ms-playwright.playwright",

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,0 +1,34 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+	"files": {
+		"ignore": ["./content/**"],
+		"ignoreUnknown": true
+	},
+	"formatter": {
+		"enabled": true,
+		"lineWidth": 100
+	},
+	"linter": {
+		"enabled": false,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"organizeImports": {
+		"enabled": false
+	},
+	/** https://github.com/biomejs/biome/issues/2763#issuecomment-2102183051 */
+	"overrides": [
+		{
+			"include": ["**/package.json"],
+			"formatter": {
+				"lineWidth": 1
+			}
+		}
+	],
+	"vcs": {
+		"clientKind": "git",
+		"enabled": true,
+		"useIgnoreFile": true
+	}
+}

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 		"analyze": "nuxt analyze",
 		"build": "nuxt build --dotenv ./.env.local",
 		"dev": "nuxt dev --dotenv ./.env.local",
-		"format:check": "prettier . \"!./content/**\" --cache --check --ignore-path ./.gitignore",
-		"format:fix": "pnpm run format:check --write",
+		"format:check": "biome format .",
+		"format:fix": "pnpm run format:check --fix",
 		"lint:check": "run-p --continue-on-error \"lint:*:check\"",
 		"lint:fix": "run-p --continue-on-error \"lint:*:fix\"",
 		"lint:code:check": "eslint . --cache --ext .js,.ts,.vue --ignore-path ./.gitignore",
@@ -60,10 +60,10 @@
 		"@acdh-oeaw/eslint-config-nuxt": "^1.0.15",
 		"@acdh-oeaw/eslint-config-playwright": "^1.0.9",
 		"@acdh-oeaw/eslint-config-vue": "^1.0.14",
-		"@acdh-oeaw/prettier-config": "^2.0.0",
 		"@acdh-oeaw/stylelint-config": "^2.0.1",
 		"@acdh-oeaw/tailwindcss-preset": "^0.0.22",
 		"@acdh-oeaw/tsconfig": "^1.1.1",
+		"@biomejs/biome": "^1.8.3",
 		"@nuxt/devtools": "^1.3.6",
 		"@playwright/test": "^1.44.1",
 		"@types/node": "^20.14.8",
@@ -78,7 +78,6 @@
 		"lint-staged": "^15.2.7",
 		"npm-run-all2": "^6.2.0",
 		"postcss": "^8.4.38",
-		"prettier": "^3.3.2",
 		"schema-dts": "^1.1.2",
 		"simple-git-hooks": "^2.11.1",
 		"stylelint": "^16.6.1",
@@ -113,24 +112,23 @@
 		"*.@(vue)": [
 			"eslint --cache --fix",
 			"stylelint --cache --fix",
-			"prettier --cache --write"
+			"biome format --fix"
 		],
 		"*.@(js|ts)": [
 			"eslint --cache --fix",
-			"prettier --cache --write"
+			"biome format --fix"
 		],
 		"*.@(css)": [
 			"stylelint --cache --fix",
-			"prettier --cache --write"
+			"biome format --fix"
 		],
-		"*.!(css|js|ts|vue),!./content/**": "prettier --cache --ignore-unknown --write"
+		"*.!(css|js|ts|vue)": "biome format --fix"
 	},
 	"postcss": {
 		"plugins": {
 			"tailwindcss": {}
 		}
 	},
-	"prettier": "@acdh-oeaw/prettier-config",
 	"simple-git-hooks": {
 		"pre-commit": "pnpm exec lint-staged"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       '@acdh-oeaw/eslint-config-vue':
         specifier: ^1.0.14
         version: 1.0.14(@acdh-oeaw/eslint-config@1.0.9(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.14.0(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0))(eslint@8.57.0)(typescript@5.5.2))(eslint@8.57.0)
-      '@acdh-oeaw/prettier-config':
-        specifier: ^2.0.0
-        version: 2.0.0(prettier@3.3.2)
       '@acdh-oeaw/stylelint-config':
         specifier: ^2.0.1
         version: 2.0.1(postcss-html@1.7.0)(stylelint-order@6.0.4(stylelint@16.6.1(typescript@5.5.2)))(stylelint@16.6.1(typescript@5.5.2))
@@ -90,6 +87,9 @@ importers:
       '@acdh-oeaw/tsconfig':
         specifier: ^1.1.1
         version: 1.1.1(typescript@5.5.2)
+      '@biomejs/biome':
+        specifier: ^1.8.3
+        version: 1.8.3
       '@nuxt/devtools':
         specifier: ^1.3.6
         version: 1.3.6(rollup@4.18.0)(vite@5.3.1(@types/node@20.14.8)(terser@5.31.1))
@@ -132,9 +132,6 @@ importers:
       postcss:
         specifier: ^8.4.38
         version: 8.4.38
-      prettier:
-        specifier: ^3.3.2
-        version: 3.3.2
       schema-dts:
         specifier: ^1.1.2
         version: 1.1.2(typescript@5.5.2)
@@ -184,11 +181,6 @@ packages:
   '@acdh-oeaw/lib@0.1.12':
     resolution: {integrity: sha512-yNAjUxcoqvEXX+YsqWqOqCOJeFg6oYL2Q+bVdhu6LEQU1MGpcMbo7haSTX12X8UYZjIU6oWpHrZfdKZZxRH23Q==}
     engines: {node: '>=20', pnpm: '>=9'}
-
-  '@acdh-oeaw/prettier-config@2.0.0':
-    resolution: {integrity: sha512-PhjHkJRb5K5uWMZ6s6IzNLvBns4Ei+osR6g/XmItFb0B844VOsU6iO3DbRyrHo8zTpMzsftkxVxT9S/b3KVmtQ==}
-    peerDependencies:
-      prettier: 3.x
 
   '@acdh-oeaw/stylelint-config@2.0.1':
     resolution: {integrity: sha512-1OP+u0pJkaXztfDc+n3zHGPJ1q0PVowyEYCl7unqORpeZ48pNicHJ32z+iAON29fBascKD507Ca9GWUgDPXu6A==}
@@ -383,6 +375,59 @@ packages:
   '@babel/types@7.24.7':
     resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@1.8.3':
+    resolution: {integrity: sha512-/uUV3MV+vyAczO+vKrPdOW0Iaet7UnJMU4bNMinggGJTAnBPjCoLEYcyYtYHNnUNYlv4xZMH6hVIQCAozq8d5w==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@1.8.3':
+    resolution: {integrity: sha512-9DYOjclFpKrH/m1Oz75SSExR8VKvNSSsLnVIqdnKexj6NwmiMlKk94Wa1kZEdv6MCOHGHgyyoV57Cw8WzL5n3A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@1.8.3':
+    resolution: {integrity: sha512-UeW44L/AtbmOF7KXLCoM+9PSgPo0IDcyEUfIoOXYeANaNXXf9mLUwV1GeF2OWjyic5zj6CnAJ9uzk2LT3v/wAw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@1.8.3':
+    resolution: {integrity: sha512-9yjUfOFN7wrYsXt/T/gEWfvVxKlnh3yBpnScw98IF+oOeCYb5/b/+K7YNqKROV2i1DlMjg9g/EcN9wvj+NkMuQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64@1.8.3':
+    resolution: {integrity: sha512-fed2ji8s+I/m8upWpTJGanqiJ0rnlHOK3DdxsyVLZQ8ClY6qLuPc9uehCREBifRJLl/iJyQpHIRufLDeotsPtw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@1.8.3':
+    resolution: {integrity: sha512-UHrGJX7PrKMKzPGoEsooKC9jXJMa28TUSMjcIlbDnIO4EAavCoVmNQaIuUSH0Ls2mpGMwUIf+aZJv657zfWWjA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64@1.8.3':
+    resolution: {integrity: sha512-I8G2QmuE1teISyT8ie1HXsjFRz9L1m5n83U1O6m30Kw+kPMPSKjag6QGUn+sXT8V+XWIZxFFBoTDEDZW2KPDDw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-win32-arm64@1.8.3':
+    resolution: {integrity: sha512-J+Hu9WvrBevfy06eU1Na0lpc7uR9tibm9maHynLIoAjLZpQU3IW+OKHUtyL8p6/3pT2Ju5t5emReeIS2SAxhkQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@1.8.3':
+    resolution: {integrity: sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@cloudflare/kv-asset-handler@0.3.2':
     resolution: {integrity: sha512-EeEjMobfuJrwoctj7FA1y1KEbM0+Q1xSjobIEyie9k4haVEBB7vkDvsasw1pM3rO39mL2akxIAzLMUAtrMHZhA==}
@@ -4544,11 +4589,6 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.3.2:
-    resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
-    engines: {node: '>=14'}
-    hasBin: true
-
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -5895,10 +5935,6 @@ snapshots:
 
   '@acdh-oeaw/lib@0.1.12': {}
 
-  '@acdh-oeaw/prettier-config@2.0.0(prettier@3.3.2)':
-    dependencies:
-      prettier: 3.3.2
-
   '@acdh-oeaw/stylelint-config@2.0.1(postcss-html@1.7.0)(stylelint-order@6.0.4(stylelint@16.6.1(typescript@5.5.2)))(stylelint@16.6.1(typescript@5.5.2))':
     dependencies:
       stylelint: 16.6.1(typescript@5.5.2)
@@ -6158,6 +6194,41 @@ snapshots:
       '@babel/helper-string-parser': 7.24.7
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
+
+  '@biomejs/biome@1.8.3':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 1.8.3
+      '@biomejs/cli-darwin-x64': 1.8.3
+      '@biomejs/cli-linux-arm64': 1.8.3
+      '@biomejs/cli-linux-arm64-musl': 1.8.3
+      '@biomejs/cli-linux-x64': 1.8.3
+      '@biomejs/cli-linux-x64-musl': 1.8.3
+      '@biomejs/cli-win32-arm64': 1.8.3
+      '@biomejs/cli-win32-x64': 1.8.3
+
+  '@biomejs/cli-darwin-arm64@1.8.3':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@1.8.3':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@1.8.3':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@1.8.3':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@1.8.3':
+    optional: true
+
+  '@biomejs/cli-linux-x64@1.8.3':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@1.8.3':
+    optional: true
+
+  '@biomejs/cli-win32-x64@1.8.3':
+    optional: true
 
   '@cloudflare/kv-asset-handler@0.3.2':
     dependencies:
@@ -11325,8 +11396,6 @@ snapshots:
     optional: true
 
   prelude-ls@1.2.1: {}
-
-  prettier@3.3.2: {}
 
   pretty-bytes@6.1.1: {}
 


### PR DESCRIPTION
replaces `prettier` with `biome`'s formatter. currently, still using `eslint`, `stylelint` and `lint-staged`, which could be replaced by biome in the future, once it supports type-aware lint rules.